### PR TITLE
Add interactive bear button demo with flow visualization

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Bear I/O Demo</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="layout">
+      <section class="scene" aria-label="Bear with a big red button">
+        <div class="bear" role="img" aria-label="A friendly cartoon bear">
+          <span class="bear-decoration" aria-hidden="true"></span>
+          <span class="eye" aria-hidden="true"></span>
+          <span class="nose" aria-hidden="true"></span>
+          <span class="mouth" aria-hidden="true"></span>
+        </div>
+        <button id="bear-button" class="bear-button" type="button" aria-describedby="status">
+          Press Me
+        </button>
+        <p id="status" class="status" aria-live="polite">Press the button to start the program.</p>
+      </section>
+
+      <section class="explanation" aria-label="Program flow visualisation">
+        <div class="pseudocode" aria-live="polite">
+          <h2>Pseudocode</h2>
+          <ol>
+            <li id="pseudo-wait">wait for button press</li>
+            <li id="pseudo-handle">handle button press event</li>
+            <li id="pseudo-flow">update flow diagram step</li>
+            <li id="pseudo-sound">play bear sound</li>
+            <li id="pseudo-done">reset and wait again</li>
+          </ol>
+        </div>
+
+        <div class="flow">
+          <h2>Flow Diagram</h2>
+          <div class="flow-diagram">
+            <div class="flow-node" id="node-wait">
+              <span class="node-title">Input</span>
+              <span class="node-body">Button is pressed</span>
+            </div>
+            <div class="flow-arrow" aria-hidden="true">&#10132;</div>
+            <div class="flow-node" id="node-handle">
+              <span class="node-title">Logic</span>
+              <span class="node-body">Click event handler runs</span>
+            </div>
+            <div class="flow-arrow" aria-hidden="true">&#10132;</div>
+            <div class="flow-node" id="node-flow">
+              <span class="node-title">Process</span>
+              <span class="node-body">Update UI &amp; plan sound</span>
+            </div>
+            <div class="flow-arrow" aria-hidden="true">&#10132;</div>
+            <div class="flow-node" id="node-sound">
+              <span class="node-title">Output</span>
+              <span class="node-body">Bear sound plays</span>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+    <script src="script.js" defer></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,170 @@
+const button = document.getElementById('bear-button');
+const statusEl = document.getElementById('status');
+const pseudoItems = Array.from(document.querySelectorAll('.pseudocode li'));
+const flowNodes = Array.from(document.querySelectorAll('.flow-node'));
+
+const STEP_CONFIG = [
+  {
+    pseudoId: 'pseudo-handle',
+    nodeId: 'node-handle',
+    message: 'Event handler executes the program logic.',
+    duration: 900,
+  },
+  {
+    pseudoId: 'pseudo-flow',
+    nodeId: 'node-flow',
+    message: 'Program updates the flow diagram and prepares the sound.',
+    duration: 900,
+  },
+  {
+    pseudoId: 'pseudo-sound',
+    nodeId: 'node-sound',
+    message: 'Output stage: bear sound plays!',
+    duration: 1200,
+    action: playBearSound,
+  },
+  {
+    pseudoId: 'pseudo-done',
+    nodeId: null,
+    message: 'Program resets and waits for the next interaction.',
+    duration: 900,
+  },
+];
+
+let audioCtx;
+let timers = [];
+
+function getAudioContext() {
+  if (!audioCtx) {
+    const AudioContext = window.AudioContext || window.webkitAudioContext;
+    audioCtx = new AudioContext();
+  }
+  return audioCtx;
+}
+
+function playBearSound() {
+  const ctx = getAudioContext();
+
+  ctx.resume().then(() => {
+    const now = ctx.currentTime;
+
+    const carrier = ctx.createOscillator();
+    carrier.type = 'sawtooth';
+    carrier.frequency.setValueAtTime(110, now);
+    carrier.frequency.exponentialRampToValueAtTime(55, now + 0.8);
+
+    const modulator = ctx.createOscillator();
+    modulator.type = 'triangle';
+    modulator.frequency.setValueAtTime(30, now);
+
+    const gain = ctx.createGain();
+    gain.gain.setValueAtTime(0.0001, now);
+    gain.gain.exponentialRampToValueAtTime(0.5, now + 0.05);
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.9);
+
+    const modulationGain = ctx.createGain();
+    modulationGain.gain.setValueAtTime(40, now);
+
+    modulator.connect(modulationGain);
+    modulationGain.connect(carrier.frequency);
+    carrier.connect(gain);
+    gain.connect(ctx.destination);
+
+    carrier.start(now);
+    modulator.start(now);
+    carrier.stop(now + 1);
+    modulator.stop(now + 1);
+  }).catch(() => {
+    // ignore resume errors triggered by rapid replays
+  });
+}
+
+function clearTimers() {
+  timers.forEach((id) => clearTimeout(id));
+  timers = [];
+}
+
+function setPseudoState(id, state) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  if (state === 'active') {
+    pseudoItems.forEach((item) => item.classList.remove('active'));
+    el.classList.add('active');
+  } else if (state === 'completed') {
+    el.classList.remove('active');
+    el.classList.add('completed');
+  } else if (state === 'reset') {
+    el.classList.remove('active', 'completed');
+  }
+}
+
+function setFlowNodeState(id, state) {
+  if (!id) return;
+  const el = document.getElementById(id);
+  if (!el) return;
+  if (state === 'active') {
+    flowNodes.forEach((node) => node.classList.remove('active'));
+    el.classList.add('active');
+  } else if (state === 'completed') {
+    el.classList.remove('active');
+    el.classList.add('completed');
+  } else if (state === 'reset') {
+    el.classList.remove('active', 'completed');
+  }
+}
+
+function resetVisualState() {
+  clearTimers();
+  pseudoItems.forEach((item) => item.classList.remove('active', 'completed'));
+  flowNodes.forEach((node) => node.classList.remove('active', 'completed'));
+  setPseudoState('pseudo-wait', 'active');
+  statusEl.textContent = 'Press the button to start the program.';
+  button.disabled = false;
+}
+
+function runFlow(index = 0) {
+  if (index >= STEP_CONFIG.length) {
+    statusEl.textContent = 'Program finished this cycle. Resetting to wait for the next input.';
+    const resetId = setTimeout(resetVisualState, 1200);
+    timers.push(resetId);
+    return;
+  }
+
+  const step = STEP_CONFIG[index];
+  setPseudoState(step.pseudoId, 'active');
+  setFlowNodeState(step.nodeId, 'active');
+  statusEl.textContent = step.message;
+
+  if (typeof step.action === 'function') {
+    step.action();
+  }
+
+  const timeoutId = setTimeout(() => {
+    setPseudoState(step.pseudoId, 'completed');
+    setFlowNodeState(step.nodeId, 'completed');
+    runFlow(index + 1);
+  }, step.duration);
+
+  timers.push(timeoutId);
+}
+
+button.addEventListener('click', () => {
+  clearTimers();
+  button.disabled = true;
+
+  pseudoItems.forEach((item) => item.classList.remove('active', 'completed'));
+  flowNodes.forEach((node) => node.classList.remove('active', 'completed'));
+
+  setPseudoState('pseudo-wait', 'completed');
+  setFlowNodeState('node-wait', 'active');
+  statusEl.textContent = 'Input detected: the button press travels into the program.';
+
+  const waitId = setTimeout(() => {
+    setFlowNodeState('node-wait', 'completed');
+    runFlow();
+  }, 700);
+
+  timers.push(waitId);
+});
+
+resetVisualState();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,298 @@
+:root {
+  color-scheme: light dark;
+  --background: #f0f4ff;
+  --panel: #ffffffcc;
+  --text: #1c1c1c;
+  --accent: #ff3b3b;
+  --highlight: #ffd166;
+  --completed: #8bc34a;
+  font-family: 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #cde3ff 0%, #f0f4ff 40%, #ffffff 100%);
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: minmax(280px, 320px) minmax(320px, 1fr);
+  gap: 2rem;
+  width: min(980px, 100%);
+  background: var(--panel);
+  border-radius: 24px;
+  padding: 2rem;
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.1);
+  backdrop-filter: blur(10px);
+}
+
+.scene {
+  position: relative;
+  background: linear-gradient(180deg, #fefefe 0%, #e3efff 100%);
+  border-radius: 20px;
+  padding: 2rem 1.5rem 2.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1rem;
+  overflow: hidden;
+}
+
+.status {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #333;
+}
+
+.bear {
+  width: 200px;
+  height: 180px;
+  position: relative;
+  background: #6f4d2d;
+  border-radius: 140px 140px 110px 110px;
+  box-shadow: inset -6px -12px 0 rgba(0, 0, 0, 0.12);
+  overflow: hidden;
+}
+
+.bear::before,
+.bear::after {
+  content: '';
+  position: absolute;
+  background: #6f4d2d;
+}
+
+.bear::before {
+  width: 70px;
+  height: 70px;
+  border-radius: 50%;
+  top: -30px;
+  left: 15px;
+  box-shadow: 100px 0 0 0 #6f4d2d;
+}
+
+.bear::after {
+  width: 70px;
+  height: 60px;
+  border-radius: 45px;
+  top: 45px;
+  left: 65px;
+  background: #f5d6a3;
+  box-shadow: inset 0 -8px 0 rgba(0, 0, 0, 0.1);
+  z-index: 2;
+}
+
+.bear .eye,
+.bear .nose,
+.bear .mouth {
+  position: absolute;
+  display: block;
+  z-index: 3;
+}
+
+.bear .eye {
+  width: 12px;
+  height: 16px;
+  background: #111;
+  border-radius: 50%;
+  top: 50px;
+  left: 62px;
+  box-shadow: 62px 0 0 0 #111;
+}
+
+.bear .nose {
+  width: 24px;
+  height: 16px;
+  background: #111;
+  border-radius: 50% 50% 70% 70%;
+  top: 74px;
+  left: 88px;
+}
+
+.bear .mouth {
+  width: 40px;
+  height: 24px;
+  border-bottom: 5px solid #111;
+  border-radius: 0 0 70px 70px;
+  top: 94px;
+  left: 78px;
+}
+
+.bear-decoration {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  display: block;
+  z-index: 1;
+}
+
+.bear-decoration::before,
+.bear-decoration::after {
+  content: '';
+  position: absolute;
+  background: rgba(255, 255, 255, 0.4);
+  border-radius: 50%;
+}
+
+.bear-decoration::before {
+  width: 110px;
+  height: 110px;
+  top: -40px;
+  left: 120px;
+}
+
+.bear-decoration::after {
+  width: 80px;
+  height: 80px;
+  bottom: -20px;
+  right: 100px;
+}
+
+.bear-button {
+  font-size: 1.15rem;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  border: none;
+  color: #fff;
+  background: radial-gradient(circle at 30% 30%, #ff7b7b, #d60000 65%);
+  box-shadow: 0 12px 18px rgba(214, 0, 0, 0.35);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.bear-button:active {
+  transform: translateY(3px);
+  box-shadow: 0 6px 10px rgba(214, 0, 0, 0.3);
+}
+
+.bear-button:disabled {
+  cursor: not-allowed;
+  filter: grayscale(0.3) brightness(0.8);
+}
+
+.explanation {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.pseudocode,
+.flow {
+  background: #fefefecc;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.05);
+}
+
+.pseudocode h2,
+.flow h2 {
+  margin-top: 0;
+  font-size: 1.2rem;
+}
+
+.pseudocode ol {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.pseudocode li {
+  padding: 0.35rem 0.5rem;
+  border-radius: 10px;
+  transition: background-color 0.3s ease, color 0.3s ease;
+  background: rgba(0, 0, 0, 0.03);
+}
+
+.pseudocode li.active {
+  background: var(--highlight);
+}
+
+.pseudocode li.completed {
+  background: var(--completed);
+  color: #0f2e00;
+}
+
+.flow-diagram {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(140px, 1fr));
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.flow-node {
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 12px;
+  padding: 0.75rem;
+  border: 2px solid transparent;
+  transition: border-color 0.3s ease, background-color 0.3s ease;
+  min-height: 100px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  gap: 0.35rem;
+}
+
+.flow-arrow {
+  font-size: 2rem;
+  color: rgba(0, 0, 0, 0.35);
+  text-align: center;
+}
+
+.flow-node .node-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.flow-node .node-body {
+  font-size: 0.85rem;
+}
+
+.flow-node.active {
+  border-color: var(--highlight);
+  background: rgba(255, 209, 102, 0.3);
+}
+
+.flow-node.completed {
+  border-color: var(--completed);
+  background: rgba(139, 195, 74, 0.25);
+}
+
+@media (max-width: 900px) {
+  body {
+    padding: 1.5rem;
+  }
+
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .flow-diagram {
+    grid-template-columns: repeat(2, minmax(140px, 1fr));
+  }
+
+  .flow-arrow:nth-of-type(2n) {
+    transform: rotate(90deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a static HTML scene with a cartoon bear, big red button, and program-flow explanation panels
- style the bear, button, pseudocode list, and flow diagram to emphasise the input-to-output journey
- script the button to animate the flow diagram, highlight pseudocode, and synthesise a bear-like sound

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d4305a60d0832ba7e03b0cbea288ae