### PR TITLE
Fix overflow of explanation panels

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -185,6 +185,12 @@ body {
   gap: 1.5rem;
 }
 
+.explanation > * {
+  min-width: 0;
+  width: 100%;
+  max-width: 100%;
+}
+
 .pseudocode,
 .flow {
   background: #fefefecc;


### PR DESCRIPTION
## Summary
- ensure the pseudocode and flow panels respect the width of their parent grid
- allow the explanation section's children to shrink without overflowing

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d57399251c832ba3ceec942243bb49